### PR TITLE
Add predis dependency; add save_path hint in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@ To enable redis session in your shopware 5, just follow this easy steps.
 
 1. Create/update your engine/Shopware/Components/DependencyInjection/services_local.xml with `<service id="session_factory" class="b3nl\SWRedis\DI\Bridge\Session" />`
 2. Overwrite the the session savehandler in your shopware config: `'session' => ['save_handler' => 'redis']`
-3. And define a redis config with the key `sessionredis` if you like. Please use the config for a [predis/predis](https://github.com/nrk/predis) client. 
+3. You also might need to set the `save_path` of your session like this: `'session' => ['save_path' => 'tcp://localhost:6379?weight=1']`
+4. And define a redis config with the key `sessionredis` if you like. Please use the config for a [predis/predis](https://github.com/nrk/predis) client.

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.4",
+        "predis/predis": "1.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4",


### PR DESCRIPTION
Hi,

just played around with it a bit and found, that the predis dependency was missing (or was it intentionally?). Also I had to specify the 'save_path' for the session to work properly, so I also added a hint for that. 
